### PR TITLE
Add missing output module and sync with PyPI v0.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,8 +136,8 @@ cython_debug/
 *.swo
 *~
 
-# Project specific
-output/
+# Project specific - output directory for generated BloodHound files
+/output/
 *.zip
 *.json
 !tests/fixtures/*.json

--- a/certihound/output/__init__.py
+++ b/certihound/output/__init__.py
@@ -1,0 +1,8 @@
+"""BloodHound CE output generation."""
+
+from .bloodhound import BloodHoundOutput
+from .nodes import NodeGenerator
+from .edges import EdgeGenerator
+from .writer import OutputWriter
+
+__all__ = ["BloodHoundOutput", "NodeGenerator", "EdgeGenerator", "OutputWriter"]

--- a/certihound/output/bloodhound.py
+++ b/certihound/output/bloodhound.py
@@ -1,0 +1,330 @@
+"""BloodHound CE output generation orchestrator."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .nodes import NodeGenerator
+from .edges import EdgeGenerator
+from ..acl.parser import SecurityDescriptorParser
+from ..detection import (
+    detect_esc1,
+    detect_esc3_agent,
+    detect_esc3_target,
+    detect_esc4,
+    detect_esc6,
+    detect_esc9,
+    detect_esc10,
+    detect_esc13,
+)
+from ..detection.esc13 import enumerate_issuance_policies
+from ..acl.rights import is_low_privileged_sid
+
+if TYPE_CHECKING:
+    from ..objects.certtemplate import CertTemplate
+    from ..objects.enterpriseca import EnterpriseCA
+    from ..objects.rootca import RootCA
+    from ..objects.ntauthstore import NTAuthStore
+    from ..objects.aiaca import AIACA
+    from ..ldap.connection import LDAPConnection
+
+
+class BloodHoundOutput:
+    """Orchestrates BloodHound CE output generation."""
+
+    BHCE_VERSION = 6
+
+    def __init__(
+        self,
+        domain: str,
+        domain_sid: str,
+        connection: "LDAPConnection" | None = None,
+    ):
+        self.domain = domain.upper()
+        self.domain_sid = domain_sid
+        self.connection = connection
+
+        self.node_generator = NodeGenerator(domain, domain_sid)
+        self.edge_generator = EdgeGenerator(domain_sid)
+
+        # Collected data
+        self.templates: list["CertTemplate"] = []
+        self.enterprise_cas: list["EnterpriseCA"] = []
+        self.root_cas: list["RootCA"] = []
+        self.ntauth_stores: list["NTAuthStore"] = []
+        self.aia_cas: list["AIACA"] = []
+
+        # Detection results
+        self.vulnerabilities: list[dict] = []
+        self.issuance_policies: dict[str, str] = {}
+
+    def add_templates(self, templates: list["CertTemplate"]) -> None:
+        """Add certificate templates."""
+        self.templates.extend(templates)
+
+    def add_enterprise_cas(self, cas: list["EnterpriseCA"]) -> None:
+        """Add Enterprise CAs."""
+        self.enterprise_cas.extend(cas)
+
+    def add_root_cas(self, cas: list["RootCA"]) -> None:
+        """Add Root CAs."""
+        self.root_cas.extend(cas)
+
+    def add_ntauth_stores(self, stores: list["NTAuthStore"]) -> None:
+        """Add NTAuth stores."""
+        self.ntauth_stores.extend(stores)
+
+    def add_aia_cas(self, cas: list["AIACA"]) -> None:
+        """Add AIA CAs."""
+        self.aia_cas.extend(cas)
+
+    def process_template_acls(self) -> None:
+        """Process ACLs for all templates to extract enrollment rights."""
+        for template in self.templates:
+            if template.security_descriptor_raw:
+                sd_parser = SecurityDescriptorParser(template.security_descriptor_raw)
+                template.aces = sd_parser.get_aces_for_bloodhound()
+
+                # Extract enrollment principals
+                rights = sd_parser.get_enrollment_rights()
+                template.enrollment_principals = [r.sid for r in rights if r.can_enroll]
+
+    def process_ca_acls(self) -> None:
+        """Process ACLs for all CAs to extract enrollment rights."""
+        for ca in self.enterprise_cas:
+            if ca.security_descriptor_raw:
+                sd_parser = SecurityDescriptorParser(ca.security_descriptor_raw)
+                ca.aces = sd_parser.get_aces_for_bloodhound()
+
+                rights = sd_parser.get_enrollment_rights()
+                ca.enrollment_principals = [r.sid for r in rights if r.can_enroll]
+
+    def enumerate_issuance_policies(self) -> None:
+        """Enumerate issuance policies with group links for ESC13."""
+        if self.connection:
+            self.issuance_policies = enumerate_issuance_policies(self.connection)
+
+    def detect_vulnerabilities(self) -> None:
+        """Run all vulnerability detection."""
+        for template in self.templates:
+            for ca in self.enterprise_cas:
+                # ESC1
+                result = detect_esc1(template, ca, self.domain_sid)
+                if result:
+                    template.is_vulnerable = True
+                    template.vulnerabilities.append("ESC1")
+                    self.vulnerabilities.append({
+                        "type": "ESC1",
+                        "template": template.cn,
+                        "ca": ca.cn,
+                        "principals": result.vulnerable_principals,
+                        "reasons": result.reasons,
+                    })
+
+                    # Generate edges
+                    for principal in result.vulnerable_principals:
+                        edge = self.edge_generator.generate_adcsesc1_edge(
+                            principal, template, ca
+                        )
+                        self.edge_generator.edges.append(edge)
+
+                # ESC3 Agent
+                agent_result = detect_esc3_agent(template, ca, self.domain_sid)
+                if agent_result:
+                    template.is_vulnerable = True
+                    template.vulnerabilities.append("ESC3-Agent")
+                    self.vulnerabilities.append({
+                        "type": "ESC3-Agent",
+                        "template": template.cn,
+                        "ca": ca.cn,
+                        "principals": agent_result.vulnerable_principals,
+                        "reasons": agent_result.reasons,
+                    })
+
+                # ESC3 Target
+                target_result = detect_esc3_target(template, ca)
+                if target_result:
+                    template.vulnerabilities.append("ESC3-Target")
+
+                # ESC4
+                if template.security_descriptor_raw:
+                    sd_parser = SecurityDescriptorParser(template.security_descriptor_raw)
+                    esc4_result = detect_esc4(template, ca, sd_parser, self.domain_sid)
+                    if esc4_result:
+                        template.is_vulnerable = True
+                        template.vulnerabilities.append("ESC4")
+                        self.vulnerabilities.append({
+                            "type": "ESC4",
+                            "template": template.cn,
+                            "ca": ca.cn,
+                            "principals": [p["sid"] for p in esc4_result.vulnerable_principals],
+                            "reasons": esc4_result.reasons,
+                        })
+
+                        for vuln_principal in esc4_result.vulnerable_principals:
+                            edge = self.edge_generator.generate_adcsesc4_edge(
+                                vuln_principal["sid"], template, ca
+                            )
+                            self.edge_generator.edges.append(edge)
+
+                # ESC6
+                esc6_results = detect_esc6(template, ca, self.domain_sid)
+                for esc6_result in esc6_results:
+                    template.is_vulnerable = True
+                    template.vulnerabilities.append(f"ESC6{esc6_result.variant}")
+                    self.vulnerabilities.append({
+                        "type": f"ESC6{esc6_result.variant}",
+                        "template": template.cn,
+                        "ca": ca.cn,
+                        "principals": esc6_result.vulnerable_principals,
+                        "reasons": esc6_result.reasons,
+                    })
+
+                # ESC13
+                if self.issuance_policies:
+                    esc13_result = detect_esc13(
+                        template, ca, self.domain_sid, self.issuance_policies
+                    )
+                    if esc13_result:
+                        template.is_vulnerable = True
+                        template.vulnerabilities.append("ESC13")
+                        self.vulnerabilities.append({
+                            "type": "ESC13",
+                            "template": template.cn,
+                            "ca": ca.cn,
+                            "principals": esc13_result.vulnerable_principals,
+                            "issuance_policy": esc13_result.issuance_policy_oid,
+                            "linked_group": esc13_result.linked_group_dn,
+                            "reasons": esc13_result.reasons,
+                        })
+
+    def generate_relationship_edges(self) -> None:
+        """Generate non-traversable relationship edges."""
+        # PublishedTo edges
+        for template in self.templates:
+            for ca in self.enterprise_cas:
+                if template.cn in ca.certificate_templates:
+                    edge = self.edge_generator.generate_publishedto_edge(template, ca)
+                    self.edge_generator.edges.append(edge)
+
+        # TrustedForNTAuth edges
+        for ca in self.enterprise_cas:
+            for ntauth in self.ntauth_stores:
+                ntauth_edge = self.edge_generator.generate_trustedforntauth_edge(ca, ntauth)
+                if ntauth_edge:
+                    self.edge_generator.edges.append(ntauth_edge)
+
+        # NTAuthStoreFor edges
+        for ntauth in self.ntauth_stores:
+            edge = self.edge_generator.generate_ntauthstorefor_edge(ntauth)
+            self.edge_generator.edges.append(edge)
+
+        # HostsCAService edges
+        for ca in self.enterprise_cas:
+            hosts_edge = self.edge_generator.generate_hostscaservice_edge(ca)
+            if hosts_edge:
+                self.edge_generator.edges.append(hosts_edge)
+
+        # Enroll edges for templates
+        for template in self.templates:
+            # BloodHound expects just the GUID in uppercase
+            template_id = template.object_guid.upper().strip("{}") if template.object_guid else ""
+            for principal_sid in template.enrollment_principals:
+                edge = self.edge_generator.generate_enroll_edge(principal_sid, template_id)
+                self.edge_generator.edges.append(edge)
+
+        # Enroll edges for CAs
+        for ca in self.enterprise_cas:
+            # BloodHound expects just the GUID in uppercase
+            ca_id = ca.object_guid.upper().strip("{}") if ca.object_guid else ""
+            for principal_sid in ca.enrollment_principals:
+                edge = self.edge_generator.generate_enroll_edge(principal_sid, ca_id)
+                self.edge_generator.edges.append(edge)
+
+        # GoldenCert edges
+        for ca in self.enterprise_cas:
+            golden_edge = self.edge_generator.generate_goldencert_edge(ca)
+            if golden_edge:
+                self.edge_generator.edges.append(golden_edge)
+
+    def generate_output(self) -> dict[str, Any]:
+        """Generate complete BloodHound CE output.
+
+        Note: Call process_template_acls(), process_ca_acls(),
+        detect_vulnerabilities(), and generate_relationship_edges()
+        before calling this method.
+        """
+        # Build output structure
+        output = {
+            "certtemplates": {
+                "meta": {
+                    "methods": 0,
+                    "type": "certtemplates",
+                    "count": len(self.templates),
+                    "version": self.BHCE_VERSION,
+                },
+                "data": [
+                    self.node_generator.generate_certtemplate_node(t)
+                    for t in self.templates
+                ],
+            },
+            "enterprisecas": {
+                "meta": {
+                    "methods": 0,
+                    "type": "enterprisecas",
+                    "count": len(self.enterprise_cas),
+                    "version": self.BHCE_VERSION,
+                },
+                "data": [
+                    self.node_generator.generate_enterpriseca_node(ca, self.templates)
+                    for ca in self.enterprise_cas
+                ],
+            },
+            "rootcas": {
+                "meta": {
+                    "methods": 0,
+                    "type": "rootcas",
+                    "count": len(self.root_cas),
+                    "version": self.BHCE_VERSION,
+                },
+                "data": [self.node_generator.generate_rootca_node(ca) for ca in self.root_cas],
+            },
+            "ntauthstores": {
+                "meta": {
+                    "methods": 0,
+                    "type": "ntauthstores",
+                    "count": len(self.ntauth_stores),
+                    "version": self.BHCE_VERSION,
+                },
+                "data": [
+                    self.node_generator.generate_ntauthstore_node(s) for s in self.ntauth_stores
+                ],
+            },
+            "aiacas": {
+                "meta": {
+                    "methods": 0,
+                    "type": "aiacas",
+                    "count": len(self.aia_cas),
+                    "version": self.BHCE_VERSION,
+                },
+                "data": [self.node_generator.generate_aiaca_node(ca) for ca in self.aia_cas],
+            },
+            "edges": self.edge_generator.get_all_edges(),
+            "vulnerabilities": self.vulnerabilities,
+        }
+
+        return output
+
+    def get_summary(self) -> dict:
+        """Get summary of collected data and findings."""
+        return {
+            "domain": self.domain,
+            "templates": len(self.templates),
+            "enterprise_cas": len(self.enterprise_cas),
+            "root_cas": len(self.root_cas),
+            "ntauth_stores": len(self.ntauth_stores),
+            "aia_cas": len(self.aia_cas),
+            "vulnerabilities": len(self.vulnerabilities),
+            "edges": len(self.edge_generator.edges),
+            "vulnerable_templates": len([t for t in self.templates if t.is_vulnerable]),
+        }

--- a/certihound/output/edges.py
+++ b/certihound/output/edges.py
@@ -1,0 +1,370 @@
+"""BloodHound CE edge generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..objects.certtemplate import CertTemplate
+    from ..objects.enterpriseca import EnterpriseCA
+    from ..objects.ntauthstore import NTAuthStore
+    from ..objects.rootca import RootCA
+
+
+@dataclass
+class EdgeDefinition:
+    """Edge definition for BloodHound CE."""
+
+    start_node: str  # ObjectIdentifier
+    end_node: str  # ObjectIdentifier
+    edge_type: str
+    edge_props: dict
+
+
+class EdgeGenerator:
+    """Generate BloodHound CE compatible edges."""
+
+    def __init__(self, domain_sid: str):
+        self.domain_sid = domain_sid
+        self.edges: list[dict] = []
+
+    def add_edge(
+        self,
+        start_node: str,
+        end_node: str,
+        edge_type: str,
+        edge_props: dict | None = None,
+    ) -> None:
+        """Add an edge to the collection."""
+        self.edges.append({
+            "StartNode": start_node,
+            "EndNode": end_node,
+            "EdgeType": edge_type,
+            "EdgeProps": edge_props or {"isacl": False},
+        })
+
+    # ==================== Non-Traversable Edges ====================
+
+    def _normalize_guid(self, guid: str | None) -> str:
+        """Normalize GUID to uppercase without curly braces."""
+        if not guid:
+            return ""
+        return guid.upper().strip("{}")
+
+    def generate_publishedto_edge(
+        self,
+        template: "CertTemplate",
+        ca: "EnterpriseCA",
+    ) -> dict:
+        """Generate PublishedTo edge (CertTemplate -> EnterpriseCA)."""
+        template_id = self._normalize_guid(template.object_guid)
+        ca_id = self._normalize_guid(ca.object_guid)
+        return {
+            "StartNode": template_id,
+            "EndNode": ca_id,
+            "EdgeType": "PublishedTo",
+            "EdgeProps": {"isacl": False},
+        }
+
+    def generate_trustedforntauth_edge(
+        self,
+        ca: "EnterpriseCA",
+        ntauth: "NTAuthStore",
+    ) -> dict | None:
+        """Generate TrustedForNTAuth edge (EnterpriseCA -> NTAuthStore)."""
+        # Check if CA cert is in NTAuth store
+        if not ntauth.is_ca_trusted(ca.cert_thumbprint):
+            return None
+
+        ca_id = self._normalize_guid(ca.object_guid)
+        ntauth_id = self._normalize_guid(ntauth.object_guid)
+        return {
+            "StartNode": ca_id,
+            "EndNode": ntauth_id,
+            "EdgeType": "TrustedForNTAuth",
+            "EdgeProps": {"isacl": False},
+        }
+
+    def generate_ntauthstorefor_edge(
+        self,
+        ntauth: "NTAuthStore",
+    ) -> dict:
+        """Generate NTAuthStoreFor edge (NTAuthStore -> Domain)."""
+        ntauth_id = self._normalize_guid(ntauth.object_guid)
+        return {
+            "StartNode": ntauth_id,
+            "EndNode": self.domain_sid,
+            "EdgeType": "NTAuthStoreFor",
+            "EdgeProps": {"isacl": False},
+        }
+
+    def generate_hostscaservice_edge(
+        self,
+        ca: "EnterpriseCA",
+    ) -> dict | None:
+        """Generate HostsCAService edge (Computer -> EnterpriseCA)."""
+        if not ca.hosting_computer_sid:
+            return None
+
+        ca_id = self._normalize_guid(ca.object_guid)
+        return {
+            "StartNode": ca.hosting_computer_sid,
+            "EndNode": ca_id,
+            "EdgeType": "HostsCAService",
+            "EdgeProps": {"isacl": False},
+        }
+
+    def generate_enroll_edge(
+        self,
+        principal_id: str,
+        target_id: str,
+        is_inherited: bool = False,
+    ) -> dict:
+        """Generate Enroll edge (Principal -> CertTemplate/EnterpriseCA)."""
+        return {
+            "StartNode": principal_id,
+            "EndNode": target_id,
+            "EdgeType": "Enroll",
+            "EdgeProps": {
+                "isacl": True,
+                "isinherited": is_inherited,
+            },
+        }
+
+    def generate_enrollonbehalfof_edge(
+        self,
+        agent_template_id: str,
+        target_template_id: str,
+    ) -> dict:
+        """Generate EnrollOnBehalfOf edge (CertTemplate -> CertTemplate)."""
+        return {
+            "StartNode": agent_template_id,
+            "EndNode": target_template_id,
+            "EdgeType": "EnrollOnBehalfOf",
+            "EdgeProps": {"isacl": False},
+        }
+
+    def generate_issuedsignedby_edge(
+        self,
+        ca: "EnterpriseCA",
+        signer_id: str,
+    ) -> dict:
+        """Generate IssuedSignedBy edge (EnterpriseCA -> EnterpriseCA/RootCA)."""
+        ca_id = self._normalize_guid(ca.object_guid)
+        signer_id_normalized = self._normalize_guid(signer_id)
+        return {
+            "StartNode": ca_id,
+            "EndNode": signer_id_normalized,
+            "EdgeType": "IssuedSignedBy",
+            "EdgeProps": {"isacl": False},
+        }
+
+    def generate_enterprisecafor_edge(
+        self,
+        ca: "EnterpriseCA",
+        root_ca: "RootCA",
+    ) -> dict:
+        """Generate EnterpriseCAFor edge (EnterpriseCA -> RootCA)."""
+        ca_id = self._normalize_guid(ca.object_guid)
+        root_ca_id = self._normalize_guid(root_ca.object_guid)
+        return {
+            "StartNode": ca_id,
+            "EndNode": root_ca_id,
+            "EdgeType": "EnterpriseCAFor",
+            "EdgeProps": {"isacl": False},
+        }
+
+    def generate_rootcafor_edge(
+        self,
+        root_ca: "RootCA",
+    ) -> dict:
+        """Generate RootCAFor edge (RootCA -> Domain)."""
+        root_ca_id = self._normalize_guid(root_ca.object_guid)
+        return {
+            "StartNode": root_ca_id,
+            "EndNode": self.domain_sid,
+            "EdgeType": "RootCAFor",
+            "EdgeProps": {"isacl": False},
+        }
+
+    def generate_delegatedenrollmentagent_edge(
+        self,
+        agent_principal_id: str,
+        template: "CertTemplate",
+    ) -> dict:
+        """Generate DelegatedEnrollmentAgent edge (Principal -> CertTemplate)."""
+        template_id = self._normalize_guid(template.object_guid)
+        return {
+            "StartNode": agent_principal_id,
+            "EndNode": template_id,
+            "EdgeType": "DelegatedEnrollmentAgent",
+            "EdgeProps": {"isacl": False},
+        }
+
+    # ==================== Traversable Edges (Attack Paths) ====================
+
+    def generate_adcsesc1_edge(
+        self,
+        principal_id: str,
+        template: "CertTemplate",
+        ca: "EnterpriseCA",
+    ) -> dict:
+        """Generate ADCSESC1 edge (Principal -> Domain)."""
+        return {
+            "StartNode": principal_id,
+            "EndNode": self.domain_sid,
+            "EdgeType": "ADCSESC1",
+            "EdgeProps": {
+                "isacl": False,
+                "certtemplate": template.distinguished_name,
+                "enterpriseca": ca.distinguished_name,
+            },
+        }
+
+    def generate_adcsesc3_edge(
+        self,
+        principal_id: str,
+        agent_template: "CertTemplate",
+        target_template: "CertTemplate",
+        ca: "EnterpriseCA",
+    ) -> dict:
+        """Generate ADCSESC3 edge (Principal -> Domain)."""
+        return {
+            "StartNode": principal_id,
+            "EndNode": self.domain_sid,
+            "EdgeType": "ADCSESC3",
+            "EdgeProps": {
+                "isacl": False,
+                "agenttemplate": agent_template.distinguished_name,
+                "targettemplate": target_template.distinguished_name,
+                "enterpriseca": ca.distinguished_name,
+            },
+        }
+
+    def generate_adcsesc4_edge(
+        self,
+        principal_id: str,
+        template: "CertTemplate",
+        ca: "EnterpriseCA",
+    ) -> dict:
+        """Generate ADCSESC4 edge (Principal -> Domain)."""
+        return {
+            "StartNode": principal_id,
+            "EndNode": self.domain_sid,
+            "EdgeType": "ADCSESC4",
+            "EdgeProps": {
+                "isacl": False,
+                "certtemplate": template.distinguished_name,
+                "enterpriseca": ca.distinguished_name,
+            },
+        }
+
+    def generate_adcsesc6_edge(
+        self,
+        principal_id: str,
+        template: "CertTemplate",
+        ca: "EnterpriseCA",
+        variant: str = "a",
+    ) -> dict:
+        """Generate ADCSESC6a/ADCSESC6b edge (Principal -> Domain)."""
+        edge_type = f"ADCSESC6{variant}"
+        return {
+            "StartNode": principal_id,
+            "EndNode": self.domain_sid,
+            "EdgeType": edge_type,
+            "EdgeProps": {
+                "isacl": False,
+                "certtemplate": template.distinguished_name,
+                "enterpriseca": ca.distinguished_name,
+            },
+        }
+
+    def generate_adcsesc9_edge(
+        self,
+        principal_id: str,
+        template: "CertTemplate",
+        ca: "EnterpriseCA",
+        variant: str = "a",
+    ) -> dict:
+        """Generate ADCSESC9a/ADCSESC9b edge (Principal -> Domain)."""
+        edge_type = f"ADCSESC9{variant}"
+        return {
+            "StartNode": principal_id,
+            "EndNode": self.domain_sid,
+            "EdgeType": edge_type,
+            "EdgeProps": {
+                "isacl": False,
+                "certtemplate": template.distinguished_name,
+                "enterpriseca": ca.distinguished_name,
+            },
+        }
+
+    def generate_adcsesc10_edge(
+        self,
+        principal_id: str,
+        template: "CertTemplate",
+        ca: "EnterpriseCA",
+        variant: str = "a",
+    ) -> dict:
+        """Generate ADCSESC10a/ADCSESC10b edge (Principal -> Domain)."""
+        edge_type = f"ADCSESC10{variant}"
+        return {
+            "StartNode": principal_id,
+            "EndNode": self.domain_sid,
+            "EdgeType": edge_type,
+            "EdgeProps": {
+                "isacl": False,
+                "certtemplate": template.distinguished_name,
+                "enterpriseca": ca.distinguished_name,
+            },
+        }
+
+    def generate_adcsesc13_edge(
+        self,
+        principal_id: str,
+        template: "CertTemplate",
+        ca: "EnterpriseCA",
+        issuance_policy_oid: str,
+        linked_group_dn: str,
+    ) -> dict:
+        """Generate ADCSESC13 edge (Principal -> Domain)."""
+        return {
+            "StartNode": principal_id,
+            "EndNode": self.domain_sid,
+            "EdgeType": "ADCSESC13",
+            "EdgeProps": {
+                "isacl": False,
+                "certtemplate": template.distinguished_name,
+                "enterpriseca": ca.distinguished_name,
+                "issuancepolicyoid": issuance_policy_oid,
+                "linkedgroup": linked_group_dn,
+            },
+        }
+
+    def generate_goldencert_edge(
+        self,
+        ca: "EnterpriseCA",
+    ) -> dict | None:
+        """Generate GoldenCert edge (Computer -> Domain)."""
+        if not ca.hosting_computer_sid:
+            return None
+
+        return {
+            "StartNode": ca.hosting_computer_sid,
+            "EndNode": self.domain_sid,
+            "EdgeType": "GoldenCert",
+            "EdgeProps": {
+                "isacl": False,
+                "caname": ca.cn,
+                "cadistinguishedname": ca.distinguished_name,
+            },
+        }
+
+    def get_all_edges(self) -> list[dict]:
+        """Get all generated edges."""
+        return self.edges
+
+    def clear_edges(self) -> None:
+        """Clear all edges."""
+        self.edges = []

--- a/certihound/output/nodes.py
+++ b/certihound/output/nodes.py
@@ -1,0 +1,181 @@
+"""BloodHound CE node generation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..objects.certtemplate import CertTemplate
+    from ..objects.enterpriseca import EnterpriseCA
+    from ..objects.rootca import RootCA
+    from ..objects.ntauthstore import NTAuthStore
+    from ..objects.aiaca import AIACA
+
+
+class NodeGenerator:
+    """Generate BloodHound CE compatible nodes."""
+
+    BHCE_VERSION = 6
+
+    def __init__(self, domain: str, domain_sid: str):
+        self.domain = domain.upper()
+        self.domain_sid = domain_sid
+
+    def generate_certtemplate_node(
+        self,
+        template: "CertTemplate",
+    ) -> dict:
+        """Generate CertTemplate node for BloodHound CE."""
+        # BloodHound expects just the GUID in uppercase, no domain SID prefix
+        object_id = template.object_guid.upper().strip("{}") if template.object_guid else ""
+
+        return {
+            "ObjectIdentifier": object_id,
+            "Properties": {
+                "name": f"{template.cn.upper()}@{self.domain}",
+                "domain": self.domain,
+                "domainsid": self.domain_sid,
+                "distinguishedname": template.distinguished_name,
+                "displayname": template.display_name or template.cn,
+                "certificatenameflag": template.certificate_name_flag,
+                "enrollmentflag": template.enrollment_flag,
+                "authorizedsignatures": template.ra_signature,
+                "ekus": template.ekus,
+                "applicationpolicies": template.application_policies,
+                "effectiveekus": template.effective_ekus,
+                "schemaversion": template.schema_version,
+                "requiresmanagerapproval": template.requires_manager_approval,
+                "enrolleesuppliessubject": template.enrollee_supplies_subject,
+                "subjectaltrequireupn": template.subject_alt_require_upn,
+                "subjectaltrequiredns": template.subject_alt_require_dns,
+                "subjectaltrequirespn": template.subject_alt_require_spn,
+                "subjectaltrequiredomaindns": template.subject_alt_require_domain_dns,
+                "subjectaltrequireemail": template.subject_alt_require_email,
+                "subjectrequireemail": template.subject_require_email,
+                "nosecurityextension": template.no_security_extension,
+                "authenticationenabled": template.authentication_enabled,
+                "validityperiod": template.validity_period,
+                "renewalperiod": template.renewal_period,
+                "oid": template.oid,
+                "highvalue": template.is_vulnerable,
+            },
+            "Aces": template.aces,
+            "IsDeleted": False,
+            "IsACLProtected": False,
+            "ContainedBy": None,
+        }
+
+    def generate_enterpriseca_node(
+        self,
+        ca: "EnterpriseCA",
+        templates: list["CertTemplate"] | None = None,
+    ) -> dict:
+        """Generate EnterpriseCA node for BloodHound CE."""
+        # Build EnabledCertTemplates - TypedPrincipal format
+        # BloodHound expects just the GUID in uppercase, no domain SID prefix
+        enabled_templates = []
+        if templates:
+            for template in templates:
+                if template.cn in ca.certificate_templates:
+                    template_id = template.object_guid.upper().strip("{}") if template.object_guid else ""
+                    if template_id:
+                        enabled_templates.append({
+                            "ObjectIdentifier": template_id,
+                            "ObjectType": "CertTemplate",
+                        })
+
+        # BloodHound expects just the GUID in uppercase
+        object_id = ca.object_guid.upper().strip("{}") if ca.object_guid else ""
+
+        return {
+            "ObjectIdentifier": object_id,
+            "Properties": {
+                "name": f"{ca.cn.upper()}@{self.domain}",
+                "domain": self.domain,
+                "domainsid": self.domain_sid,
+                "distinguishedname": ca.distinguished_name,
+                "dnshostname": ca.dns_hostname,
+                "caname": ca.cn,
+                "certthumbprint": ca.cert_thumbprint,
+                "certchain": [],
+                "certname": ca.cert_name,
+                "flags": ca.flags,
+                "isuserspecifiessanenabled": ca.is_user_specifies_san_enabled,
+                "hasbasicconstraints": ca.has_basic_constraints,
+                "basicconstraintpathlength": ca.basic_constraint_path_length,
+                "highvalue": True,
+            },
+            "Aces": ca.aces,
+            "IsDeleted": False,
+            "IsACLProtected": False,
+            "EnabledCertTemplates": enabled_templates,
+            "HostingComputer": ca.hosting_computer_sid,
+            "DomainSID": self.domain_sid,
+            "ContainedBy": None,
+        }
+
+    def generate_rootca_node(self, ca: "RootCA") -> dict:
+        """Generate RootCA node for BloodHound CE."""
+        # BloodHound expects just the GUID in uppercase
+        object_id = ca.object_guid.upper().strip("{}") if ca.object_guid else ""
+
+        return {
+            "ObjectIdentifier": object_id,
+            "Properties": {
+                "name": f"{ca.cn.upper()}@{self.domain}",
+                "domain": self.domain,
+                "domainsid": self.domain_sid,
+                "distinguishedname": ca.distinguished_name,
+                "certthumbprint": ca.cert_thumbprint,
+                "certname": ca.cert_subject,
+                "hasbasicconstraints": ca.has_basic_constraints,
+                "highvalue": True,
+            },
+            "IsDeleted": False,
+            "IsACLProtected": False,
+            "DomainSID": self.domain_sid,
+            "ContainedBy": None,
+        }
+
+    def generate_ntauthstore_node(self, store: "NTAuthStore") -> dict:
+        """Generate NTAuthStore node for BloodHound CE."""
+        # BloodHound expects just the GUID in uppercase
+        object_id = store.object_guid.upper().strip("{}") if store.object_guid else ""
+
+        return {
+            "ObjectIdentifier": object_id,
+            "Properties": {
+                "name": f"{store.cn.upper()}@{self.domain}",
+                "domain": self.domain,
+                "domainsid": self.domain_sid,
+                "distinguishedname": store.distinguished_name,
+                "certthumbprints": store.trusted_thumbprints,
+                "certificatecount": store.certificate_count,
+                "highvalue": True,
+            },
+            "IsDeleted": False,
+            "IsACLProtected": False,
+            "DomainSID": self.domain_sid,
+            "ContainedBy": None,
+        }
+
+    def generate_aiaca_node(self, ca: "AIACA") -> dict:
+        """Generate AIACA node for BloodHound CE."""
+        # BloodHound expects just the GUID in uppercase
+        object_id = ca.object_guid.upper().strip("{}") if ca.object_guid else ""
+
+        return {
+            "ObjectIdentifier": object_id,
+            "Properties": {
+                "name": f"{ca.cn.upper()}@{self.domain}",
+                "domain": self.domain,
+                "domainsid": self.domain_sid,
+                "distinguishedname": ca.distinguished_name,
+                "certthumbprint": ca.cert_thumbprint,
+                "certname": ca.cert_subject,
+                "highvalue": False,
+            },
+            "IsDeleted": False,
+            "IsACLProtected": False,
+            "ContainedBy": None,
+        }

--- a/certihound/output/writer.py
+++ b/certihound/output/writer.py
@@ -1,0 +1,140 @@
+"""Output file writing for BloodHound CE."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+console = Console()
+
+
+class OutputWriter:
+    """Write BloodHound CE output files."""
+
+    def __init__(self, output_dir: str | Path, domain: str):
+        self.output_dir = Path(output_dir)
+        self.domain = domain.replace(".", "_").upper()
+        self.timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+
+    def ensure_output_dir(self) -> None:
+        """Create output directory if it doesn't exist."""
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_filename(self, suffix: str) -> str:
+        """Generate consistent filename."""
+        return f"{self.timestamp}_{self.domain}_certihound_{suffix}"
+
+    def write_json(self, data: dict[str, Any], filename: str) -> Path:
+        """Write data to JSON file."""
+        self.ensure_output_dir()
+        filepath = self.output_dir / filename
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, default=str)
+        return filepath
+
+    def write_bloodhound_json(self, output: dict[str, Any]) -> list[Path]:
+        """Write BloodHound CE compatible JSON files."""
+        self.ensure_output_dir()
+        written_files = []
+
+        # Write each object type to separate file
+        # Note: BloodHound CE processes edges from node Aces, not separate relationship files
+        for obj_type in ["certtemplates", "enterprisecas", "rootcas", "ntauthstores", "aiacas"]:
+            if obj_type in output and output[obj_type]["data"]:
+                filename = self.get_filename(f"{obj_type}.json")
+                filepath = self.write_json(output[obj_type], filename)
+                written_files.append(filepath)
+                console.print(f"[green][+] Written {filepath}[/green]")
+
+        return written_files
+
+    def write_bloodhound_zip(self, output: dict[str, Any]) -> Path:
+        """Write BloodHound CE compatible ZIP file."""
+        self.ensure_output_dir()
+        zip_filename = self.get_filename("bloodhound.zip")
+        zip_path = self.output_dir / zip_filename
+
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            # Write each object type
+            # Note: BloodHound CE processes edges from node Aces, not separate relationship files
+            for obj_type in ["certtemplates", "enterprisecas", "rootcas", "ntauthstores", "aiacas"]:
+                if obj_type in output and output[obj_type]["data"]:
+                    json_content = json.dumps(output[obj_type], indent=2, default=str)
+                    zf.writestr(f"{self.timestamp}_{obj_type}.json", json_content)
+
+        console.print(f"[green][+] Written {zip_path}[/green]")
+        return zip_path
+
+    def write_vulnerability_report(self, vulnerabilities: list[dict]) -> Path:
+        """Write vulnerability report."""
+        self.ensure_output_dir()
+        filename = self.get_filename("vulnerabilities.json")
+        filepath = self.output_dir / filename
+
+        report = {
+            "generated": datetime.now().isoformat(),
+            "domain": self.domain,
+            "total_vulnerabilities": len(vulnerabilities),
+            "vulnerabilities": vulnerabilities,
+        }
+
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, default=str)
+
+        console.print(f"[green][+] Written vulnerability report: {filepath}[/green]")
+        return filepath
+
+    def write_summary(self, summary: dict) -> Path:
+        """Write collection summary."""
+        self.ensure_output_dir()
+        filename = self.get_filename("summary.json")
+        filepath = self.output_dir / filename
+
+        summary["generated"] = datetime.now().isoformat()
+
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2, default=str)
+
+        console.print(f"[green][+] Written summary: {filepath}[/green]")
+        return filepath
+
+    def write_all(
+        self,
+        output: dict[str, Any],
+        format: str = "zip",
+    ) -> dict[str, list[Path] | Path]:
+        """Write all output files."""
+        result: dict[str, list[Path] | Path] = {}
+
+        if format in ("json", "both"):
+            result["json_files"] = self.write_bloodhound_json(output)
+
+        if format in ("zip", "both"):
+            result["zip_file"] = self.write_bloodhound_zip(output)
+
+        if output.get("vulnerabilities"):
+            result["vulnerability_report"] = self.write_vulnerability_report(
+                output["vulnerabilities"]
+            )
+
+        # Always write summary
+        from .bloodhound import BloodHoundOutput
+
+        summary = {
+            "domain": self.domain,
+            "templates": len(output.get("certtemplates", {}).get("data", [])),
+            "enterprise_cas": len(output.get("enterprisecas", {}).get("data", [])),
+            "root_cas": len(output.get("rootcas", {}).get("data", [])),
+            "ntauth_stores": len(output.get("ntauthstores", {}).get("data", [])),
+            "aia_cas": len(output.get("aiacas", {}).get("data", [])),
+            "edges": len(output.get("edges", [])),
+            "vulnerabilities": len(output.get("vulnerabilities", [])),
+        }
+        result["summary"] = self.write_summary(summary)
+
+        return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "certihound"
-version = "0.1.0"
+version = "0.1.1"
 description = "Linux-native AD CS collector library for BloodHound CE - enumerate ADCS and export to BloodHound format"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
- Add certihound/output/ module (nodes.py, edges.py, bloodhound.py, writer.py)
  that was missing from the repo but present in PyPI package
- Fix .gitignore to only ignore root /output/ directory, not certihound/output/
- Update version to 0.1.1 to match PyPI